### PR TITLE
fix paranthese (compiler warnings)

### DIFF
--- a/src/compat.c
+++ b/src/compat.c
@@ -1140,9 +1140,9 @@ colorspec parse_color
                 paren = true;
                 break;
               }
-            else if (c >= 'a' && c <= 'z' || c >= '0' && c <= '9' || c >= 'A' && c <= 'Z')
+            else if ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || (c >= 'A' && c <= 'Z'))
               {
-                if (c > 'f' && c <= 'z' || c > 'F' && c <= 'Z')
+                if ((c > 'f' && c <= 'z') || (c > 'F' && c <= 'Z'))
                   {
                     nonhex = true;
                   } /*if*/

--- a/src/dvdcompile.c
+++ b/src/dvdcompile.c
@@ -647,9 +647,9 @@ static unsigned char *compilecs
             if
               (
                     (
-                        i2 > 0 && i2 < 128 /* jump to non-entry menu */
+                        (i2 > 0 && i2 < 128) /* jump to non-entry menu */
                     ||
-                        i2 == 0 && i1 == 1 /* jump to VMGM */
+                        (i2 == 0 && i1 == 1) /* jump to VMGM */
                     )
                 &&
                     ismenu == VTYPE_VTS
@@ -759,9 +759,9 @@ static unsigned char *compilecs
               (
                   i1 >= 2 /*jump to titleset*/
               ||
-                  i1 == 1 /*jump to VMGM*/ && i2 >= 128 /*title*/
+                  (i1 == 1 /*jump to VMGM*/ && i2 >= 128) /*title*/
               ||
-                  ismenu == VTYPE_VMGM && i2 >= 128 && cs->i3 /*chapter/program/cell*/
+                  (ismenu == VTYPE_VMGM && i2 >= 128 && cs->i3) /*chapter/program/cell*/
               )
               {
                 //  VMGM    TS  TPGC    CHXX
@@ -1033,7 +1033,7 @@ static unsigned char *compilecs
                     (
                         cs->i1 >= 2 /*titleset*/
                     ||
-                        cs->i1 == 0 /*no VMGM/titleset*/ && ismenu != VTYPE_VMGM
+                        (cs->i1 == 0 /*no VMGM/titleset*/ && ismenu != VTYPE_VMGM)
                     )
               )
               {
@@ -1154,7 +1154,7 @@ static unsigned int negateif(unsigned int ifs)
   /* negates the comparison op part of a value returned from extractif. */
   {
     return
-            ifs & 0x8ffffff /* remove comparison op */
+            (ifs & 0x8ffffff) /* remove comparison op */
         |
             negatecompare((ifs >> 24) & 7) << 24; /* replace with opposite comparison */
   } /*negateif*/
@@ -1413,9 +1413,11 @@ void vm_optimize(const unsigned char *obuf, unsigned char *buf, unsigned char **
                 ||
                     (b[8 + 1] & 0xf) == 7
                 ||
+                    (
                         (b[8 + 1] & 0xf) == 1
                     &&
                         (b[8 + 7] & 0x1f) != 0
+                    )
                 )
             &&
                 countreferences(buf, *end, curline + 1) == 0
@@ -1451,9 +1453,11 @@ void vm_optimize(const unsigned char *obuf, unsigned char *buf, unsigned char **
                 ||
                     (b[8 + 1] & 0x7f) == 7
                 ||
+                    (
                         (b[8 + 1] & 0x7f) == 1
                     &&
                         (b[8 + 7] & 0x1f) != 0
+                    )
                 )
             &&
                 countreferences(buf, *end, curline + 1) == 0

--- a/src/dvdunauthor.c
+++ b/src/dvdunauthor.c
@@ -905,7 +905,7 @@ static void findpalette(int vob, const pgcit_t *pgcs, const uint32_t **palette, 
                 |
                     p->playback_time.second << 8
                 |
-                    p->playback_time.frame_u & 0x3f;
+                    (p->playback_time.frame_u & 0x3f);
             if (!(*palette) || ptime > *length)
               {
                 if (*palette && memcmp(*palette, p->palette, 16 * sizeof(uint32_t)))

--- a/src/dvdvob.c
+++ b/src/dvdvob.c
@@ -365,7 +365,7 @@ static void transpose_ts(unsigned char *buf, pts_t tsoffs)
                     buf[17 + sysoffs] == MPID_PRIVATE1
                       /* audio or subpicture stream */
                 ||
-                    buf[17 + sysoffs] >= MPID_AUDIO_FIRST && buf[17 + sysoffs] <= MPID_VIDEO_LAST
+                    (buf[17 + sysoffs] >= MPID_AUDIO_FIRST && buf[17 + sysoffs] <= MPID_VIDEO_LAST)
                       /* audio or video stream */
                 )
             &&

--- a/src/spuunmux.c
+++ b/src/spuunmux.c
@@ -1335,7 +1335,7 @@ l_01ba:
                           (
                                 cbuf[next_word] == stream_number + 32 /* DVD-Video stream nr */
                             ||
-                                cbuf[next_word] == 0x70 && cbuf[next_word + 1] == stream_number
+                                (cbuf[next_word] == 0x70 && cbuf[next_word + 1] == stream_number)
                                   /* SVCD stream nr */
                           )
                           {

--- a/src/subgen-encode.c
+++ b/src/subgen-encode.c
@@ -123,7 +123,7 @@ static void svcd_rotate(stinfo *s)
         for (i = 0; i < s->xd * s->yd; i++)
             s->fimg[i] = s->fimg[i] - j & 3;
         for (i = 0; i < 4; i++)
-            p[i] = s->pal[i + j & 3];
+            p[i] = s->pal[(i + j) & 3];
         memcpy(s->pal, p, 4 * sizeof(colorspec));
       } /*if*/
   } /*svcd_rotate*/

--- a/src/subgen-image.c
+++ b/src/subgen-image.c
@@ -543,11 +543,13 @@ ui_found:
                   (
                         tri == -1
                     ||
+                        (
                             s->img.pal[(tri >> 16) & 0xFF].a == 0
                         &&
                             s->hlt.pal[(tri >> 8) & 0xFF].a == 0
                         &&
                             s->sel.pal[tri & 0xFF].a == 0
+                        )
                   )
                   {
                     spare = k;

--- a/src/subreader.c
+++ b/src/subreader.c
@@ -2139,9 +2139,11 @@ sub_data *sub_read_file(const char *filename, float movie_fps)
       (
             suboverlap_enabled == 2
         ||
+            (
                 suboverlap_enabled
             &&
                 (sub_format == SUB_JACOSUB || sub_format == SUB_SSA)
+            )
       )
       {
       // here we manage overlapping subtitles

--- a/src/subrender.c
+++ b/src/subrender.c
@@ -188,7 +188,7 @@ static void alloc_buf(mp_osd_obj_t * obj)
         obj->bbox.x2 = obj->bbox.x1;
     if (obj->bbox.y2 < obj->bbox.y1)
         obj->bbox.y2 = obj->bbox.y1;
-    obj->stride = (obj->bbox.x2 - obj->bbox.x1) * 4 + 7 & ~7; /* round up to multiple of 8 bytes--why bother? */
+    obj->stride = ((obj->bbox.x2 - obj->bbox.x1) * 4 + 7) & ~7; /* round up to multiple of 8 bytes--why bother? */
     len = obj->stride * (obj->bbox.y2 - obj->bbox.y1);
     if (obj->allocated < len)
       {


### PR DESCRIPTION
e.g.:
warning: suggest parentheses around '&&' within '||'

Cheers
 Chris
